### PR TITLE
Add incremental mode

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -262,9 +262,10 @@ export class DirectoutInstance extends InstanceBase<ModuleConfig> {
 		// eslint-disable-next-line @typescript-eslint/no-this-alias
 		const self = this
 
-		const makeActionOption = (param: Option): SomeCompanionActionInputField => {
+		const makeActionOption = (param: Option): SomeCompanionActionInputField[] => {
+			const baseId = param.id ?? param.label ?? `unknown_${param.type}_option`
 			const option: Record<string, unknown> = {
-				id: param.id ?? param.label ?? `unknown_${param.type}_option`,
+				id: baseId,
 				label: param.label ?? `Unknown`,
 			}
 			if (param.tooltip) option.tooltip = param.tooltip
@@ -286,7 +287,8 @@ export class DirectoutInstance extends InstanceBase<ModuleConfig> {
 					option.choices = []
 					option.default = ''
 				}
-			} else if (param.type === 'number' && !param.incremental) {
+				return [option as unknown as SomeCompanionActionInputField]
+			} else if (param.type === 'number' && param.incremental === false) {
 				option.type = 'number'
 				option.min = param.min ?? 0
 				option.max = param.max ?? 1024
@@ -296,14 +298,42 @@ export class DirectoutInstance extends InstanceBase<ModuleConfig> {
 				if (Number(option.default) > Number(option.max)) option.default = option.max
 				if (option.tooltip === undefined)
 					option.tooltip = `Value range between ${option.min} and ${option.max}, increments ${option.step}`
-			} else if (param.type === 'number' && param.incremental) {
-				option.type = 'number'
-				option.step = param.step ?? 1
-				option.default = 1
-				option.max = param.max ?? 1024
-				// no min, have to allow negatives for incremental - clamped in action
-				if (option.tooltip === undefined)
-					option.tooltip = `Step size ${option.step}. Use negative values to decrement. Final value clamped to valid range.`
+				return [option as unknown as SomeCompanionActionInputField]
+			} else if (param.type === 'number' && param.incremental !== false) {
+				// generate two inputs: one for absolute mode, one for incremental mode
+				const min = param.min ?? 0
+				const max = param.max ?? 1024
+				const step = param.step ?? 1
+				const absDefault = Number(param.default ?? 0)
+
+				const absoluteOption: Record<string, unknown> = {
+					id: baseId,
+					label: param.label ?? `Unknown`,
+					type: 'number',
+					min: min,
+					max: max,
+					step: step,
+					default: Math.max(min, Math.min(max, absDefault)),
+					tooltip: `Value range between ${min} and ${max}, increments ${step}`,
+					isVisible: (options: CompanionOptionValues) => options['incremental'] !== true,
+				}
+
+				const incrementalOption: Record<string, unknown> = {
+					id: `${baseId}_inc`,
+					label: param.label ?? `Unknown`,
+					type: 'number',
+					min: -max,
+					max: max,
+					step: step,
+					default: step,
+					tooltip: `Adjustment amount. Negative values decrement. Result clamped to ${min}..${max}`,
+					isVisible: (options: CompanionOptionValues) => options['incremental'] === true,
+				}
+
+				return [
+					absoluteOption as unknown as SomeCompanionActionInputField,
+					incrementalOption as unknown as SomeCompanionActionInputField,
+				]
 			} else if (param.type === 'boolean') {
 				option.type = 'dropdown'
 				option.choices = param.choices ?? [
@@ -311,14 +341,16 @@ export class DirectoutInstance extends InstanceBase<ModuleConfig> {
 					{ label: 'Off', id: '%%false%%' },
 				] // toggle will be added by enrich function
 				option.default = param.default ?? '%%true%%'
+				return [option as unknown as SomeCompanionActionInputField]
 			} else if (param.type === 'string') {
 				option.type = 'textinput'
 				option.useVariables = { local: true }
 				option.default = param.default ?? ''
 				if (param.regex) option.regex = param.regex
+				return [option as unknown as SomeCompanionActionInputField]
 			}
 
-			return option as unknown as SomeCompanionActionInputField
+			return [option as unknown as SomeCompanionActionInputField]
 		}
 
 		const makeFeedbackOption = (param: Option) => {
@@ -370,7 +402,7 @@ export class DirectoutInstance extends InstanceBase<ModuleConfig> {
 		}
 
 		const makeIncrementalOption = (param: Option): SomeCompanionActionInputField[] => {
-			if (param.incremental) {
+			if (param.type === 'number' && param.incremental !== false) {
 				const option: Record<string, unknown> = {
 					id: 'incremental',
 					label: 'Incremental',
@@ -466,16 +498,13 @@ export class DirectoutInstance extends InstanceBase<ModuleConfig> {
 
 							self.sendSetCmd(thisPath, value, param.translation)
 						} else if (param.type == 'number') {
-							let value = Number(options[thisKey])
-
 							// check if user selected incremental mode
-							const useIncremental = param.incremental && options['incremental'] === true
+							const useIncremental = param.incremental !== false && options['incremental'] === true
 
-							if (!useIncremental) {
-								// absolute mode: clamp to parameter range
-								if (param.min && value < param.min) value = param.min
-								if (param.max && value > param.max) value = param.max
-							}
+							// read from correct field based on mode
+							const valueKey = useIncremental ? `${thisKey}_inc` : thisKey
+							let value = Number(options[valueKey])
+
 							if (param.step)
 								value = Number(
 									(Math.round((value + Number.EPSILON) / param.step) * param.step).toFixed(
@@ -486,10 +515,11 @@ export class DirectoutInstance extends InstanceBase<ModuleConfig> {
 							if (useIncremental) {
 								// incremental mode: add to current value and clamp result
 								let newVal = Number(self.getPath(thisPath)) + value
-								if (param.max && newVal > param.max) newVal = param.max
-								if (param.min && newVal < param.min) newVal = param.min
+								if (param.max !== undefined && newVal > param.max) newVal = param.max
+								if (param.min !== undefined && newVal < param.min) newVal = param.min
 								self.sendSetCmd(thisPath, newVal)
 							} else {
+								// absolute mode: value already clamped by input bounds
 								self.sendSetCmd(thisPath, value)
 							}
 						} else {
@@ -510,7 +540,8 @@ export class DirectoutInstance extends InstanceBase<ModuleConfig> {
 						if (value === true) value = '%%true%%'
 						else if (value === false) value = '%%false%%'
 						newValues[param.key] = value
-						// self.log('debug', `learn called. value: ${value}\noptionValues: ${JSON.stringify(param, null, 2)}`)
+						// switch to absolute mode so learned value is visible
+						if (param.type === 'number') newValues['incremental'] = false
 					}
 					return { ...options, ...newValues }
 				}
@@ -518,9 +549,11 @@ export class DirectoutInstance extends InstanceBase<ModuleConfig> {
 				this.actionDefinitions[key] = {
 					name: `Set ${parameter.name}`,
 					options: [
-						...(optionOptions ? optionOptions.map((opt) => makeActionOption(opt)) : []),
-						...(parameterOptions ? parameterOptions.map((param) => enrichDropdown(makeActionOption(param))) : []),
+						...(optionOptions ? optionOptions.flatMap((opt) => makeActionOption(opt)) : []),
 						...(parameterOptions ? parameterOptions.flatMap((param) => makeIncrementalOption(param)) : []),
+						...(parameterOptions
+							? parameterOptions.flatMap((param) => makeActionOption(param).map((opt) => enrichDropdown(opt)))
+							: []),
 					],
 					callback,
 					learn,

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -26,6 +26,8 @@ export type Option = {
 	max?: number
 	/** optional step for number, 1 if omitted */
 	step?: number
+	/** make incremental rather than absolute */
+	incremental?: boolean
 }
 
 export type ParameterOption = Option & {
@@ -466,6 +468,7 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 18,
 					step: 0.1,
 					default: 0,
+					incremental: true,
 				},
 			],
 			options: [
@@ -492,6 +495,7 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 24,
 					step: 0.1,
 					default: 0,
+					incremental: true,
 				},
 			],
 			options: [
@@ -518,6 +522,7 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 24,
 					step: 0.1,
 					default: 0,
+					incremental: true,
 				},
 			],
 			options: [
@@ -701,6 +706,7 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 18,
 					step: 0.1,
 					default: 0,
+					incremental: true,
 				},
 			],
 		},
@@ -1177,8 +1183,9 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					type: 'number',
 					min: 5,
 					max: 75,
-					step: 0.1,
-					tooltip: `Values range from 5 to 75, incrementing by 0.1.`,
+					step: 1,
+					tooltip: `Values range from 5 to 75, incrementing by 1.`,
+					incremental: true,
 				},
 			],
 		},
@@ -1408,6 +1415,7 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 18,
 					step: 0.1,
 					default: 0,
+					incremental: true,
 				},
 			],
 		},
@@ -1723,6 +1731,7 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					min: -144,
 					max: 18,
 					step: 0.1,
+					incremental: true,
 				},
 			],
 		},
@@ -1877,6 +1886,7 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 65535,
 					step: 1,
 					default: 0,
+					incremental: true,
 				},
 			],
 		},

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -520,7 +520,6 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 24,
 					step: 0.1,
 					default: 0,
-					incremental: false,
 				},
 			],
 			options: [

--- a/src/parameters.ts
+++ b/src/parameters.ts
@@ -26,7 +26,7 @@ export type Option = {
 	max?: number
 	/** optional step for number, 1 if omitted */
 	step?: number
-	/** make incremental rather than absolute */
+	/** allow incremental mode, true if omitted */
 	incremental?: boolean
 }
 
@@ -468,7 +468,6 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 18,
 					step: 0.1,
 					default: 0,
-					incremental: true,
 				},
 			],
 			options: [
@@ -495,7 +494,6 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 24,
 					step: 0.1,
 					default: 0,
-					incremental: true,
 				},
 			],
 			options: [
@@ -522,7 +520,7 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 24,
 					step: 0.1,
 					default: 0,
-					incremental: true,
+					incremental: false,
 				},
 			],
 			options: [
@@ -706,7 +704,6 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 18,
 					step: 0.1,
 					default: 0,
-					incremental: true,
 				},
 			],
 		},
@@ -1185,7 +1182,6 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 75,
 					step: 1,
 					tooltip: `Values range from 5 to 75, incrementing by 1.`,
-					incremental: true,
 				},
 			],
 		},
@@ -1415,7 +1411,6 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 18,
 					step: 0.1,
 					default: 0,
-					incremental: true,
 				},
 			],
 		},
@@ -1731,7 +1726,6 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					min: -144,
 					max: 18,
 					step: 0.1,
-					incremental: true,
 				},
 			],
 		},
@@ -1886,7 +1880,6 @@ export function returnParameters(self: DirectoutInstance): Parameters {
 					max: 65535,
 					step: 1,
 					default: 0,
-					incremental: true,
 				},
 			],
 		},


### PR DESCRIPTION
Introduces an incremental option for compatible parameters, making it significantly easier to configure stream decks with rotary encoders.